### PR TITLE
Change BUILDDIR to _build and fix warning

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,7 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = pop
 SOURCEDIR     = source
-BUILDDIR      = build
+BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -8,7 +8,7 @@ if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
 set SOURCEDIR=source
-set BUILDDIR=build
+set BUILDDIR=_build
 set SPHINXPROJ=pop
 
 if "%1" == "" goto help

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,7 +15,6 @@ Welcome to pop's documentation!
    topics/pop
    topics/story
    topics/sub_patterns
-   topics/com
    topics/proc
    topics/conf
    topics/conf_integrate


### PR DESCRIPTION
Change sphinx `BUILDDIR` to `_build` which is what is currently in .gitignore.

Also fix the spinx warning: `/home/ch3ll/git/pop/doc/source/index.rst:9: WARNING: toctree contains reference to nonexisting document u'topics/com'` so the docs build properly