### PR TITLE
Update README.rst

### DIFF
--- a/doc/source/tutorial/quickstart.rst
+++ b/doc/source/tutorial/quickstart.rst
@@ -57,7 +57,7 @@ To solve this issue `pop` comes with a system to make configuration loading easy
 
 When loading configuration data, the data can come from many sources, the command line,
 environment variables, windows registery, configuration files, etc. But certian sources
-should overwirtie other sources; config files overwrite defaults, environment variables overwrite
+should overwrite other sources; config files overwrite defaults, environment variables overwrite
 config files and cli overwrites all. Also, you end up defining default configuration values
 and paramaters in multiple places to enable supporting multiple mediums for configuration input.
 Finally, you only want to have to document your configuration options in one place.


### PR DESCRIPTION
updating readme as I run through the instructions

```
pip3 install pop
python3 scripts/pop-seed poppy
```

because pip(2) could not verify certificates, and because the pop-seed script is not executable by default and creates the poppy project from the directory it was invoked from.