### PR TITLE
`CLI_CONFIG` should be `CONFIG`

### DIFF
--- a/docs/source/tutorial/quickstart.rst
+++ b/docs/source/tutorial/quickstart.rst
@@ -118,7 +118,7 @@ your configuration data.
 
 .. code-block:: python
 
-    CLI_CONFIG = {
+    CONFIG = {
             'addr': {
                 'options': ['-a'],
                 'default': '127.0.0.1',


### PR DESCRIPTION
Fixes https://github.com/saltstack/pop/issues/52

It appears that the top level key here should be `CONFIG`, not `CLI_CONFIG`

Otherwise I get a nasty stacktrace.