### PR TITLE
Fix aiohttp usage

### DIFF
--- a/docs/source/tutorial/quickstart.rst
+++ b/docs/source/tutorial/quickstart.rst
@@ -197,12 +197,12 @@ all of the functions in the `rpc` plugin subsystem over a simple http server.
 
 .. code-block:: python
 
-    import aiohttp
+    from aiohttp import web
 
     def __init__(hub):
-        app = aiohttp.web.Application()
-        app.add_routes([aiohttp.web.get('/', hub.rpc.init.router)])
-        aiohttp.web.run_app(app)
+        app = web.Application()
+        app.add_routes([web.get('/', hub.rpc.init.router)])
+        web.run_app(app)
 
     async def router(hub, request):
         data = request.json()


### PR DESCRIPTION
When going through the Quickstart I get this error when going through the `Adding more Plugin Subsystems` section here:

https://pop.readthedocs.io/en/latest/tutorial/quickstart.html#adding-more-plugin-subsystems

Here's the error I'm getting:

```
[boucha@flaco poppy]$ python3 ./run.py
Traceback (most recent call last):
  File "./run.py", line 5, in <module>
    hub.pop.sub.add('poppy.poppy')
  File "/usr/local/lib/python3.6/dist-packages/pop/contract.py", line 131, in __call__
    return self.func(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/pop/mods/pop/sub.py", line 61, in add
    root._subs[subname]._sub_init(init)
  File "/usr/local/lib/python3.6/dist-packages/pop/hub.py", line 300, in _sub_init
    self._find_mod('init', match_only=True)
  File "/usr/local/lib/python3.6/dist-packages/pop/hub.py", line 331, in _find_mod
    self._load_item(iface, bname)
  File "/usr/local/lib/python3.6/dist-packages/pop/hub.py", line 365, in _load_item
    self._prep_mod(mod, iface, bname)
  File "/usr/local/lib/python3.6/dist-packages/pop/hub.py", line 406, in _prep_mod
    pop.loader.mod_init(self._hub, mod)
  File "/usr/local/lib/python3.6/dist-packages/pop/loader.py", line 206, in mod_init
    mod.__init__(hub)
  File "/home/boucha/code/poppy/poppy/poppy/init.py", line 3, in __init__
    hub.pop.sub.add(pypath='poppy.rpc')
  File "/usr/local/lib/python3.6/dist-packages/pop/contract.py", line 131, in __call__
    return self.func(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/pop/mods/pop/sub.py", line 61, in add
    root._subs[subname]._sub_init(init)
  File "/usr/local/lib/python3.6/dist-packages/pop/hub.py", line 300, in _sub_init
    self._find_mod('init', match_only=True)
  File "/usr/local/lib/python3.6/dist-packages/pop/hub.py", line 331, in _find_mod
    self._load_item(iface, bname)
  File "/usr/local/lib/python3.6/dist-packages/pop/hub.py", line 365, in _load_item
    self._prep_mod(mod, iface, bname)
  File "/usr/local/lib/python3.6/dist-packages/pop/hub.py", line 406, in _prep_mod
    pop.loader.mod_init(self._hub, mod)
  File "/usr/local/lib/python3.6/dist-packages/pop/loader.py", line 206, in mod_init
    mod.__init__(hub)
  File "/home/boucha/code/poppy/poppy/rpc/init.py", line 6, in __init__
    app = aiohttp.web.Application()
AttributeError: module 'aiohttp' has no attribute 'web'
```

I'm not able to use this module imported like that from the python cli either.
Doing some googling I see the following:

``
from aiohttp import web
```

I'm not exactly sure why that works, but the example doesn't, but when I make the changes in the example to match the import style I found online, then the quickstart example works.