### PR TITLE
Add `CONFIG` so pop doesn't stacktrace

### DIFF
--- a/docs/source/tutorial/quickstart.rst
+++ b/docs/source/tutorial/quickstart.rst
@@ -137,6 +137,8 @@ your configuration data.
                 },
             }
 
+    CONFIG = {}
+
 Now lets change the `__init__` function in *poppy/poppy/init.py* to load up the project's config!
 
 .. code-block:: python


### PR DESCRIPTION
Adding `CONFIG` to `poppy/conf.py` stops the stacktrace, wo this PR adds it to the example conf.py.

We should evaluate whether we should have pop not stacktrace if `CONFIG` is missing.