### PR TITLE
take args from contract_context instead of originals in direct call case, too

### DIFF
--- a/pop/contract.py
+++ b/pop/contract.py
@@ -136,7 +136,7 @@ class Contracted(Wrapper):  # pylint: disable=too-few-public-methods
         if self.contract_functions['call']:
             ret = self.contract_functions['call'][0](contract_context)
         else:
-            ret = self.func(*args, **kwargs)
+            ret = self.func(*contract_context.args, **contract_context.kwargs)
         for fn in self.contract_functions['post']:
             post_ret = fn(contract_context._replace(ret=ret))
             if post_ret is not None:

--- a/tests/contracts/ctx_update.py
+++ b/tests/contracts/ctx_update.py
@@ -15,7 +15,7 @@ def pre(hub, ctx):
     assert ctx.args == [hub, False]
 
 
-def call(hub, ctx):
+def call_test_call(hub, ctx):
     '''
     '''
     assert ctx.args == [hub, False]

--- a/tests/mods/contract_ctx/ctx_update.py
+++ b/tests/mods/contract_ctx/ctx_update.py
@@ -3,5 +3,9 @@
 __contracts__ = 'ctx_update'
 
 
-def test(value):
+def test_call(hub, value):
+    return value
+
+
+def test_direct(hub, value):
     return value

--- a/tests/unit/test_contract_ctx.py
+++ b/tests/unit/test_contract_ctx.py
@@ -17,16 +17,29 @@ def test_contract_context():
     assert hub.mods.ctx.test() == 'contract executed'
 
 
-def test_contract_context_update():
+def test_contract_context_update_call():
+    # if a pre modifies args, make sure they persist when called via 'call' function
     hub = pop.hub.Hub()
     hub.pop.sub.add(
             pypath='tests.mods.contract_ctx',
             subname='mods',
             contracts_pypath='tests.contracts'
             )
-    assert hub.mods.ctx_update.test(True) == 'contract executed'
+    assert hub.mods.ctx_update.test_call(True) == 'contract executed'
     # Multiple calls have the same outcome
-    assert hub.mods.ctx_update.test(True) == 'contract executed'
+    assert hub.mods.ctx_update.test_call(True) == 'contract executed'
+
+
+def test_contract_context_update_direct():
+    # if a pre modifies args, make sure they persist when called directly
+    hub = pop.hub.Hub()
+    hub.pop.sub.add(
+            pypath='tests.mods.contract_ctx',
+            subname='mods',
+            contracts_pypath='tests.contracts'
+            )
+    assert hub.mods.ctx_update.test_direct(True) is False
+    assert hub.mods.ctx_update.test_direct(True) is False
 
 
 def test_contract_ctx_argument_retrieval():


### PR DESCRIPTION
We had a bug. I fixed it.