### PR TITLE
remove MockContracted class, return Contracted of mock_func

### DIFF
--- a/pop/mods/pop/testing.py
+++ b/pop/mods/pop/testing.py
@@ -173,26 +173,11 @@ class NoContractHub(_LazyPop):
         return partial(f.func, self._LazyPop__lut.lookup('hub'))
 
 
-class MockContracted:
-    '''
-    Creates a new contracted, but using a mock function.
-    The mock function is masked to look just like the real function.
-
-    Look up/set attributes first on the new contracted, then pass through to the mock.
-    '''
-
-    def __init__(self, c):
-        mock_func = create_autospec(c.func, spec_set=True)
-        mock_func.__module__ = c.func.__module__
-        mock_func.__dict__.update(copy.deepcopy(c.func.__dict__))
-        self.__dict__['contracted'] = Contracted(c.hub, c.contracts, mock_func, c.ref, c.name)
-        self.signature = c.signature
-
-    def __call__(self, *args, **kwargs):
-        return self.contracted(*args, **kwargs)
-
-    def __getattr__(self, attr):
-        return getattr(self.contracted, attr)
+def mock_contracted(c):
+    mock_func = create_autospec(c.func, spec_set=True)
+    mock_func.__module__ = c.func.__module__
+    mock_func.__dict__.update(copy.deepcopy(c.func.__dict__))
+    return Contracted(c.hub, c.contracts, mock_func, c.ref, c.name)
 
 
 class ContractHub(_LazyPop):
@@ -232,4 +217,4 @@ class ContractHub(_LazyPop):
         assert contract_hub.sub.mod.fn.contracts.index(contract1) < contract_hub.sub.mod.fn.contracts.index(contract2)
     '''
     def _mock_function(self, f):
-        return MockContracted(f)
+        return mock_contracted(f)

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -213,29 +213,29 @@ class TestMockContracted:
         assert self.hub.mods.testing.echo('foo') == 'contract foo'
 
     def test_contract_hub_contract(self):
-        m_echo = testing.MockContracted(self.hub.mods.testing.echo)
+        m_echo = testing.mock_contracted(self.hub.mods.testing.echo)
         m_echo.func.return_value = 'bar'
         assert m_echo('foo') == 'contract bar'
 
     def test_contract_hub_getattr(self):
-        assert testing.MockContracted(self.hub.mods.testing.echo).return_value
+        assert testing.mock_contracted(self.hub.mods.testing.echo).return_value
 
     def test_contract_hub_module(self):
-        m_echo = testing.MockContracted(self.hub.mods.testing.echo)
+        m_echo = testing.mock_contracted(self.hub.mods.testing.echo)
         func_module = self.hub.mods.testing.echo.func.__module__
         assert m_echo.func.__module__ == func_module
 
     def test_signature(self):
-        m_sig = testing.MockContracted(self.hub.mods.testing.signature_func)
+        m_sig = testing.mock_contracted(self.hub.mods.testing.signature_func)
         assert str(m_sig.signature) == "(hub, param1, param2='default')"
 
     def test_get_arguments(self):
-        m_sig = testing.MockContracted(self.hub.mods.testing.signature_func)
+        m_sig = testing.mock_contracted(self.hub.mods.testing.signature_func)
         m_sig('passed in')
 
     def test_copy_func_attributes(self):
-        echo = testing.MockContracted(self.hub.mods.testing.echo)
-        attr_func = testing.MockContracted(self.hub.mods.testing.attr_func)
+        echo = testing.mock_contracted(self.hub.mods.testing.echo)
+        attr_func = testing.mock_contracted(self.hub.mods.testing.attr_func)
 
         with pytest.raises(AttributeError):
             assert echo.func.test
@@ -255,7 +255,7 @@ class TestContractHub:
         assert self.hub.mods.testing.echo('foo') == 'contract foo'
 
     def test_contract_hub_contract(self):
-        assert isinstance(self.contract_hub.mods.testing.echo, testing.MockContracted)
+        assert isinstance(self.contract_hub.mods.testing.echo, testing.Contracted)
 
     @pytest.mark.asyncio
     async def test_async_echo(self):


### PR DESCRIPTION
After removing the flattening which allowed for access of MockContracted.func.attr as if it were MockContracted.attr, I realized we don't need a class at all - just a custom mock function to a regular contracted.